### PR TITLE
[fix][sec] Upgrade bouncycastle to 1.78

### DIFF
--- a/bouncy-castle/bc/LICENSE
+++ b/bouncy-castle/bc/LICENSE
@@ -205,6 +205,6 @@
 This projects includes binary packages with the following licenses:
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.75.jar
-    - org.bouncycastle-bcprov-jdk18on-1.75.jar
-    - org.bouncycastle-bcprov-ext-jdk18on-1.75.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.78.jar
+    - org.bouncycastle-bcprov-jdk18on-1.78.jar
+    - org.bouncycastle-bcprov-ext-jdk18on-1.78.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -613,10 +613,10 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.75.jar
-    - org.bouncycastle-bcprov-ext-jdk18on-1.75.jar
-    - org.bouncycastle-bcprov-jdk18on-1.75.jar
-    - org.bouncycastle-bcutil-jdk18on-1.75.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.78.jar
+    - org.bouncycastle-bcprov-ext-jdk18on-1.78.jar
+    - org.bouncycastle-bcprov-jdk18on-1.78.jar
+    - org.bouncycastle-bcutil-jdk18on-1.78.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -473,10 +473,10 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk18on-1.75.jar
-    - bcprov-ext-jdk18on-1.75.jar
-    - bcprov-jdk18on-1.75.jar
-    - bcutil-jdk18on-1.75.jar
+    - bcpkix-jdk18on-1.78.jar
+    - bcprov-ext-jdk18on-1.78.jar
+    - bcprov-jdk18on-1.78.jar
+    - bcutil-jdk18on-1.78.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <bouncycastle.version>1.75</bouncycastle.version>
+    <bouncycastle.version>1.78</bouncycastle.version>
     <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bc-fips.version>1.0.2.4</bouncycastle.bc-fips.version>
     <jackson.version>2.14.2</jackson.version>


### PR DESCRIPTION
### Motivation

Upgrade Bouncy Castle to 1.78 to address CVEs
https://bouncycastle.org/releasenotes.html#r1rv78

- https://www.cve.org/CVERecord?id=CVE-2024-29857 (reserved)
  - https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6613079
- https://www.cve.org/CVERecord?id=CVE-2024-30171 (reserved)
  - https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6613076
- https://www.cve.org/CVERecord?id=CVE-2024-30172 (reserved)
  - https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
